### PR TITLE
allowedips: Increase stack size

### DIFF
--- a/src/allowedips.c
+++ b/src/allowedips.c
@@ -40,14 +40,14 @@ static void push_rcu(struct allowedips_node **stack,
 		     struct allowedips_node __rcu *p, unsigned int *len)
 {
 	if (rcu_access_pointer(p)) {
-		WARN_ON(IS_ENABLED(DEBUG) && *len >= 128);
+		WARN_ON(IS_ENABLED(DEBUG) && *len >= 128 + 1);
 		stack[(*len)++] = rcu_dereference_raw(p);
 	}
 }
 
 static void root_free_rcu(struct rcu_head *rcu)
 {
-	struct allowedips_node *node, *stack[128] = {
+	struct allowedips_node *node, *stack[128 + 1] = {
 		container_of(rcu, struct allowedips_node, rcu) };
 	unsigned int len = 1;
 
@@ -60,7 +60,7 @@ static void root_free_rcu(struct rcu_head *rcu)
 
 static void root_remove_peer_lists(struct allowedips_node *root)
 {
-	struct allowedips_node *node, *stack[128] = { root };
+	struct allowedips_node *node, *stack[128 + 1] = { root };
 	unsigned int len = 1;
 
 	while (len > 0 && (node = stack[--len])) {
@@ -77,11 +77,11 @@ static void walk_remove_by_peer(struct allowedips_node __rcu **top,
 #define REF(p) rcu_access_pointer(p)
 #define DEREF(p) rcu_dereference_protected(*(p), lockdep_is_held(lock))
 #define PUSH(p) ({                                                             \
-		WARN_ON(IS_ENABLED(DEBUG) && len >= 128);                      \
+		WARN_ON(IS_ENABLED(DEBUG) && len >= 128 + 1);                      \
 		stack[len++] = p;                                              \
 	})
 
-	struct allowedips_node __rcu **stack[128], **nptr;
+	struct allowedips_node __rcu **stack[128 + 1], **nptr;
 	struct allowedips_node *node, *prev;
 	unsigned int len;
 


### PR DESCRIPTION
A stack size of 128 is insufficient in the worst-case scenario and leads to a system freeze upon stopping / using syncconf

root_free_rcu / root_remove_peer_lists:
We can have up to 128 "0" branches and 1 "1" branch pushed into the stack at once, for a total of 129 elements

walk_remove_by_peer:
With 129 possible CIDR values, we can have up to 129 elements in the stack at once

Such configurations are (very) unlikely to occur as it would require rather specific peer allowedips
However, it would still be good to guard against such scenarios as they are technically possible (I have managed to trigger said scenarios)

Signed-off-by: Damian Ho <damian_ho_xu_yang@yahoo.com>