### PR TITLE
compat: don't backport ktime_get_coarse_boottime_ns to kernel-4.18.0-394

### DIFF
--- a/src/compat/Kbuild.include
+++ b/src/compat/Kbuild.include
@@ -109,3 +109,5 @@ endif
 ifneq ($(shell grep -s -F "\#define LINUX_PACKAGE_ID \" Debian " "$(CURDIR)/include/generated/package.h"),)
 ccflags-y += -DISDEBIAN
 endif
+
+ccflags-y += -DRHEL_KERNEL_RELEASE=$(shell grep -s -E '^\#define RHEL_RELEASE[[:space:]]+"[[:digit:]]+' "$(CURDIR)/include/generated/uapi/linux/version.h"| sed 's/\./ /g'| sed 's/"/ /g' | awk '{print $$3} END {if (!NR) print "0"}')

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -16,6 +16,9 @@
 #define ISRHEL7
 #elif RHEL_MAJOR == 8
 #define ISRHEL8
+#if RHEL_MINOR >= 7 && RHEL_KERNEL_RELEASE >= 394
+#define IS_NEWER_RHEL8
+#endif
 #endif
 #endif
 #ifdef UTS_UBUNTU_RELEASE_ABI
@@ -387,7 +390,7 @@ static inline int get_random_bytes_wait(void *buf, int nbytes)
 #define system_power_efficient_wq system_unbound_wq
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0) && !defined(IS_NEWER_RHEL8)
 #include <linux/ktime.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)
 #include <linux/hrtimer.h>

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -17,7 +17,10 @@
 #elif RHEL_MAJOR == 8
 #define ISRHEL8
 #if RHEL_MINOR >= 7 && RHEL_KERNEL_RELEASE >= 394
-#define IS_NEWER_RHEL8
+#define IS_NEWER_RHEL8_394
+#endif
+#if RHEL_MINOR >= 9 && RHEL_KERNEL_RELEASE >= 483
+#define IS_NEWER_RHEL8_483
 #endif
 #endif
 #endif
@@ -390,7 +393,7 @@ static inline int get_random_bytes_wait(void *buf, int nbytes)
 #define system_power_efficient_wq system_unbound_wq
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0) && !defined(IS_NEWER_RHEL8)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0) && !defined(IS_NEWER_RHEL8_394)
 #include <linux/ktime.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)
 #include <linux/hrtimer.h>

--- a/src/peer.c
+++ b/src/peer.c
@@ -54,8 +54,12 @@ struct wg_peer *wg_peer_create(struct wg_device *wg,
 	skb_queue_head_init(&peer->staged_packet_queue);
 	wg_noise_reset_last_sent_handshake(&peer->last_sent_handshake);
 	set_bit(NAPI_STATE_NO_BUSY_POLL, &peer->napi.state);
-	netif_napi_add(wg->dev, &peer->napi, wg_packet_rx_poll,
-		       NAPI_POLL_WEIGHT);
+#if defined(IS_NEWER_RHEL8_483)
+       netif_napi_add(wg->dev, &peer->napi, wg_packet_rx_poll);
+#else
+        netif_napi_add(wg->dev, &peer->napi, wg_packet_rx_poll,
+                       NAPI_POLL_WEIGHT);
+#endif
 	napi_enable(&peer->napi);
 	list_add_tail(&peer->peer_list, &wg->peer_list);
 	INIT_LIST_HEAD(&peer->allowedips_list);


### PR DESCRIPTION
This patch aims to deal with the recent compilation breakage in CentOS 8 Stream, and the future RHEL 8.7 release. Due to a change in the kernel-4.18.0-394, which has implemented `ktime_get_coarse_boottime_ns()` and caused a redefinition error. According to the response from Red Hat Bugzilla [#2103865](https://bugzilla.redhat.com/show_bug.cgi?id=2103865). It doesn't seem that change will be reverted. So we have to deal with it in WireGuard.

In this patch, the addition in `compat.h` is actually very similar to the previous abandoned commit 99935b0. But the condition is a little more precise. There is a new definition named `RHEL_KERNEL_RELEASE` represents RHEL-specific kernel versioning. E.g., `372` from `4.18.0-372.16.1`. The `RHEL_KERNEL_RELEASE` definition is generated by the shell command in the modified `Kbuild.include`. It will return `0` if there is no RHEL kernel version found.